### PR TITLE
Create model

### DIFF
--- a/lib/domain/model/github_repo.dart
+++ b/lib/domain/model/github_repo.dart
@@ -1,0 +1,18 @@
+class GitHubRepo {
+  GitHubRepo({
+    required this.name,
+    required this.ownerAvatarUrl,
+    required this.projectLanguage,
+    required this.starsCount,
+    required this.watchersCount,
+    required this.forksCount,
+    required this.openIssuesCount,
+  });
+  final String name;
+  final String ownerAvatarUrl;
+  final String projectLanguage;
+  final int starsCount;
+  final int watchersCount;
+  final int forksCount;
+  final int openIssuesCount;
+}

--- a/lib/infra/entity/github_repo_entity.dart
+++ b/lib/infra/entity/github_repo_entity.dart
@@ -1,0 +1,45 @@
+import 'package:gethub/domain/model/github_repo.dart';
+
+class GitHubRepoEntity {
+  GitHubRepoEntity({
+    required this.name,
+    required this.ownerAvatarUrl,
+    required this.projectLanguage,
+    required this.starsCount,
+    required this.watchersCount,
+    required this.forksCount,
+    required this.openIssuesCount,
+  });
+  final String name;
+  final String ownerAvatarUrl;
+  final String projectLanguage;
+  final int starsCount;
+  final int watchersCount;
+  final int forksCount;
+  final int openIssuesCount;
+
+  factory GitHubRepoEntity.fromJson(Map<String, Object> json) {
+    final owner = json['owner'] as Map<String, Object>;
+    return GitHubRepoEntity(
+      name: json['name'] as String,
+      ownerAvatarUrl: owner['avator_url'] as String,
+      projectLanguage: json['language'] as String,
+      starsCount: json['stargazers_count'] as int,
+      watchersCount: json['watchers_count'] as int,
+      forksCount: json['forks_count'] as int,
+      openIssuesCount: json['open_issues_count'] as int,
+    );
+  }
+
+  GitHubRepo toModel() {
+    return GitHubRepo(
+      name: name,
+      ownerAvatarUrl: ownerAvatarUrl,
+      projectLanguage: projectLanguage,
+      starsCount: starsCount,
+      watchersCount: watchersCount,
+      forksCount: forksCount,
+      openIssuesCount: openIssuesCount,
+    );
+  }
+}


### PR DESCRIPTION
close #5 

## やったこと
- [x] GitHubのリポジトリを表現するGitHubRepoモデルを作成
- [x] jsonからGitHubRepoモデルへの変換を担うGitHubRepoEntityを作成

## 備考
issue段階では使用を予定していたfreezedおよびequtableについてだが、どちらも使用しなかった。
理由として、今回の要件ではGitHubのリポジトリの各値を読み取ることが目的であり、
モデルや値に振る舞いを実装する必要がなかったことがある。
