### PR TITLE
GitHubAPIの抽象クラスを削除

### DIFF
--- a/lib/domain/i_api/i_github_api.dart
+++ b/lib/domain/i_api/i_github_api.dart
@@ -1,8 +1,0 @@
-import 'package:gethub/domain/model/github_repo.dart';
-
-abstract class IGitHubAPI {
-  Future<List<GitHubRepo>> searchRepos(
-    String searchWord, {
-    required int targetPage,
-  });
-}

--- a/lib/infra/api/github_api.dart
+++ b/lib/infra/api/github_api.dart
@@ -2,14 +2,13 @@ import 'dart:io';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:gethub/domain/i_api/i_github_api.dart';
 import 'package:gethub/foundation/typedefs.dart';
 import 'package:gethub/domain/model/github_repo.dart';
 import 'package:gethub/infra/entity/github_repo_entity.dart';
 
 final gitHubAPIProvider = Provider.autoDispose(((_) => GitHubAPI()));
 
-class GitHubAPI implements IGitHubAPI {
+class GitHubAPI {
   static const url = 'https://api.github.com/search/repositories';
 
   @override


### PR DESCRIPTION
## やったこと
- [x] Dartのクラスは暗黙的インターフェースを持つためGitHubAPIの抽象クラスを削除

## 備考
ユニットテストではGitHubAPIの暗黙的インターフェースのimplementとしてFakeAPIを定義する。