### PR TITLE
ダークモード判定ロジックの修正

### DIFF
--- a/lib/foundation/is_dark_mode.dart
+++ b/lib/foundation/is_dark_mode.dart
@@ -1,6 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gethub/notifier/app_theme_notifier.dart';
 
-bool isDarkMode(BuildContext context) {
-  final Brightness brightness = MediaQuery.platformBrightnessOf(context);
-  return brightness == Brightness.dark;
-}
+final isDarkProvider = Provider.autoDispose.family<bool, Brightness>((ref, brightness) {
+  final appTheme = ref.watch(appThemeNotifierProvicer);
+  final isDevice = appTheme.isDevice;
+  final isDark = appTheme.isDark;
+
+  final deviceModeIsDark = brightness == Brightness.dark;
+
+  return (!isDevice && isDark) || (isDevice && deviceModeIsDark);
+});

--- a/lib/ui/page/detail_page.dart
+++ b/lib/ui/page/detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gethub/domain/model/github_repo.dart';
 import 'package:gethub/foundation/is_dark_mode.dart';
 import 'package:quiver/strings.dart';
@@ -25,13 +26,13 @@ class DetailPage extends StatelessWidget {
   }
 }
 
-class _RepoDetailCard extends StatelessWidget {
+class _RepoDetailCard extends ConsumerWidget {
   const _RepoDetailCard(this.repo, {Key? key}) : super(key: key);
 
-  BoxDecoration _decoration(BuildContext context) => BoxDecoration(
+  BoxDecoration _decoration(BuildContext context, bool isDark) => BoxDecoration(
       color: Theme.of(context).cardColor,
       borderRadius: BorderRadius.circular(16),
-      boxShadow: isDarkMode(context)
+      boxShadow: isDark
           ? null
           : const [
               BoxShadow(
@@ -41,9 +42,11 @@ class _RepoDetailCard extends StatelessWidget {
   final GitHubRepo repo;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDark =
+        ref.watch(isDarkProvider(MediaQuery.platformBrightnessOf(context)));
     return Container(
-      decoration: _decoration(context),
+      decoration: _decoration(context, isDark),
       child: SizedBox(
         width: double.infinity,
         child: Column(
@@ -76,8 +79,7 @@ class _RepoDetailCard extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Divider(
-                  color: isDarkMode(context) ? Colors.transparent : null),
+              child: Divider(color: isDark ? Colors.transparent : null),
             ), // LightModeの場合のみDividerが見えるようにする
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/ui/page/search_page.dart
+++ b/lib/ui/page/search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:gethub/domain/model/github_repo.dart';
+import 'package:gethub/foundation/is_dark_mode.dart';
 import 'package:gethub/notifier/search_page_notifier.dart';
 import 'package:gethub/ui/page/setting_page.dart';
 import 'package:gethub/ui/widget/repo_list_tile.dart';
@@ -88,6 +89,8 @@ class __BodyState extends ConsumerState<_Body> {
               pageState.repos,
               scrollController: _scrollController,
               errorMessage: pageState.errorMessage,
+              isDark: ref.watch(
+                  isDarkProvider(MediaQuery.platformBrightnessOf(context))),
             ),
           ],
         ),
@@ -112,11 +115,13 @@ class _RepoListView extends StatelessWidget {
     this.repos, {
     Key? key,
     required this.scrollController,
+    required this.isDark,
     this.errorMessage,
   }) : super(key: key);
   final List<GitHubRepo>? repos;
   final ScrollController scrollController;
   final String? errorMessage;
+  final bool isDark;
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +134,10 @@ class _RepoListView extends StatelessWidget {
         controller: scrollController,
         itemCount: repos!.length,
         itemBuilder: (BuildContext context, int i) {
-          return RepoListTile(repos![i]);
+          return RepoListTile(
+            repos![i],
+            isDark: isDark,
+          );
         },
       ),
     );

--- a/lib/ui/widget/repo_list_tile.dart
+++ b/lib/ui/widget/repo_list_tile.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:gethub/domain/model/github_repo.dart';
-import 'package:gethub/foundation/is_dark_mode.dart';
 import 'package:gethub/ui/page/detail_page.dart';
 
 class RepoListTile extends StatelessWidget {
-  const RepoListTile(this.repo, {Key? key}) : super(key: key);
+  const RepoListTile(this.repo, {Key? key, required this.isDark})
+      : super(key: key);
   final GitHubRepo repo;
+  final bool isDark;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +19,7 @@ class RepoListTile extends StatelessWidget {
             ListTile(title: Text(repo.name, overflow: TextOverflow.ellipsis)),
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         elevation: 8,
-        shadowColor: isDarkMode(context) ? Colors.transparent : Colors.black38,
+        shadowColor: isDark ? Colors.transparent : Colors.black38,
       ),
     );
   }


### PR DESCRIPTION
## やったこと
- [x] ダークモードかどうかを総合的に判定するProviderを作成

## 目的
既存のライトモード / ダークモードの判定ロジックは端末の設定のみを判断材料にしていたため、
アプリ内でもライトモード / ダークモードを切り替えられるようになった段階で、ケアできないケースがでてきた。
それをケアするために総合的な判定ができるProviderを作成した。