### PR TITLE
Themeの変更が保存されないことがあるバグを修正

### DIFF
--- a/lib/notifier/app_theme_notifier.dart
+++ b/lib/notifier/app_theme_notifier.dart
@@ -25,6 +25,7 @@ class AppThemeNotifier extends StateNotifier<AppThemeState> {
       state = state.copyWith(isDark: false);
     }
     _repository.setIsDeviceValue(state.isDevice);
+    _repository.setIsDarkValue(state.isDark);
   }
 
   void toggleIsDark() {
@@ -32,6 +33,7 @@ class AppThemeNotifier extends StateNotifier<AppThemeState> {
     if (state.isDark) {
       state = state.copyWith(isDevice: false);
     }
+    _repository.setIsDeviceValue(state.isDevice);
     _repository.setIsDarkValue(state.isDark);
   }
 }


### PR DESCRIPTION
## やったこと
- [x] isDeviceの変更時にisDarkの、isDarkの変更時にisDeviceの  
保存し忘れがあったのできちんと保存する

## 目的
正しくThemeが保存される様にすること

## 備考
